### PR TITLE
fix: remove auth checker for entering by scanning qr-code

### DIFF
--- a/server.js
+++ b/server.js
@@ -211,7 +211,7 @@ app.get('/events/:eventId', authenticateToken, async (req, res) => {
         res.status(500).json({ message: 'Server error fetching event details: ' + error.message });
     }
 });
-app.get('/events/:eventId/join', authenticateToken, async (req, res) => {
+app.get('/events/:eventId/join', async (req, res) => {
     const { eventId } = req.params;
     try {
         const event = await Event.findById(eventId);


### PR DESCRIPTION
When a qr code is scanned we don't need to check if the user has an authentification header as he will then be asked to register,login or join as guest.