### PR TITLE
fix : event statuses logic

### DIFF
--- a/src/components/AdminEventDetails.js
+++ b/src/components/AdminEventDetails.js
@@ -148,16 +148,16 @@ export function AdminEventsDetails() {
                             gutterBottom
                             sx={{
                                 fontWeight: 'bold',
-                                color: event.status === 'CLOSED' ? '#d32f2f' : '#388e3c', // Red for CLOSED, green for OPEN
+                                color: event.status === 'OPEN' ? '#d32f2f' : '#388e3c', // Red for CLOSED, green for OPEN
                                 backgroundColor:
-                                    event.status === 'CLOSED' ? '#ffebee' : '#e8f5e9', // Light red/green background
+                                    event.status === 'OPEN' ? '#ffebee' : '#e8f5e9', // Light red/green background
                                 padding: '4px 8px',
                                 borderRadius: 2,
                                 display: 'inline-block',
                                 textAlign: 'center',
                             }}
                         >
-                            Status: {event.status}
+                            Status: {event.status === 'OPEN' ? 'In progress' : 'Not started'}
                         </Typography>
                         <Box
                             sx={{

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -113,8 +113,8 @@ export function Events() {
                                     <Typography
                                         variant="body1"
                                         sx={{
-                                            color: event.status === 'CLOSED' ? '#d32f2f' : '#388e3c', // Red for closed, green for in progress
-                                            backgroundColor: event.status === 'CLOSED' ? '#ffebee' : '#e8f5e9', // Light red/green background
+                                            color: event.status === 'OPEN' ? '#d32f2f' : '#388e3c', // Red for closed, green for in progress
+                                            backgroundColor: event.status === 'OPEN' ? '#ffebee' : '#e8f5e9', // Light red/green background
                                             fontWeight: 'bold',
                                             padding: '4px 8px',
                                             borderRadius: 2,

--- a/src/components/EventsDetails.js
+++ b/src/components/EventsDetails.js
@@ -163,10 +163,10 @@ export function EventsDetails() {
                             sx={{
                                 fontSize: '1rem',
                                 fontWeight: 'bold',
-                                color: event.status === 'CLOSED' ? '#d32f2f' : '#388e3c', // Red for CLOSED, Green otherwise
+                                color: event.status === 'OPEN' ? '#d32f2f' : '#388e3c', // Red for CLOSED, Green otherwise
                             }}
                         >
-                            <strong>Status:</strong> {event.status}
+                            <strong>Status:</strong> {event.status === 'CLOSED' ? 'Not started' : 'In progress'}
                         </Typography>
 
                         <Box
@@ -177,36 +177,57 @@ export function EventsDetails() {
                                 gap: 2,
                             }}
                         >
-                            <TextField
-                                label="Enter Access Code"
-                                variant="outlined"
-                                fullWidth
-                                value={enteredCode}
-                                onChange={(e) => setEnteredCode(e.target.value)}
-                                error={!!error && error.includes('Invalid access code')}
-                                helperText={error.includes('Invalid access code') ? error : ''}
-                                sx={{
-                                    backgroundColor: '#f9f9f9', // Light gray text field background
-                                    borderRadius: 1,
-                                }}
-                            />
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={handleJoinEvent}
-                                sx={{
-                                    padding: 1.5,
-                                    fontSize: '1rem',
-                                    fontWeight: 'bold',
-                                    textTransform: 'none',
-                                    backgroundColor: '#0d47a1',
-                                    '&:hover': {
-                                        backgroundColor: '#0b3c8b', // Darker shade on hover
-                                    },
-                                }}
-                            >
-                                Join Event
-                            </Button>
+                            {event.status === 'CLOSED' && (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        gap: 2,
+                                    }}
+                                >
+                                    <Typography
+                                        variant="h5"
+                                        gutterBottom
+                                        sx={{
+                                            color: '#0d47a1', // Dark blue for title
+                                            fontWeight: 'bold',
+                                            textAlign: 'center',
+                                        }}
+                                    >
+                                        Join Event
+                                    </Typography>
+                                    <TextField
+                                        label="Enter Access Code"
+                                        variant="outlined"
+                                        fullWidth
+                                        value={enteredCode}
+                                        onChange={(e) => setEnteredCode(e.target.value)}
+                                        error={!!error && error.includes('Invalid access code')}
+                                        helperText={error.includes('Invalid access code') ? error : ''}
+                                        sx={{
+                                            backgroundColor: '#f9f9f9', // Light gray text field background
+                                            borderRadius: 1,
+                                        }}
+                                    />
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={handleJoinEvent}
+                                        sx={{
+                                            padding: 1.5,
+                                            fontSize: '1rem',
+                                            fontWeight: 'bold',
+                                            textTransform: 'none',
+                                            backgroundColor: '#0d47a1',
+                                            '&:hover': {
+                                                backgroundColor: '#0b3c8b', // Darker shade on hover
+                                            },
+                                        }}
+                                    >
+                                        Join Event
+                                    </Button>
+                                </Box>
+                            )}
                         </Box>
                     </CardContent>
                 </Card>

--- a/src/components/UserPage.js
+++ b/src/components/UserPage.js
@@ -104,10 +104,7 @@ function UserPage() {
                     Welcome, {userData.username}!
                 </Typography>
                 <Typography variant="body1" sx={{ color: '#424242' }}>
-                    Email: {userData.email}
-                </Typography>
-                <Typography variant="body1" sx={{ color: '#424242' }}>
-                    User ID: {userData._id}
+                    email: {userData.email}
                 </Typography>
             </Paper>
 


### PR DESCRIPTION
Fixed logical issues throughout the project. Basically if an event is open it means that it is in progress so the users can not join the event anymore. This  means that when an event is in progress it should be colored with red and vice-versa. Also, replaced "OPEN" and "CLOSED" with "In progress" and "Not started" for better clarity.