### PR TITLE
fix: remove eventId from localStorage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,7 @@ function App() {
         } catch (joinError) {
           setMessage('Failed to join event: ' + (joinError.response?.data.message || joinError.message));
           alert('Failed to join event: ' + (joinError.response?.data.message || joinError.message) + ', redirecting to user dashboard');
+          localStorage.removeItem('eventId');
           navigate(`/user`);
         }
       } else {


### PR DESCRIPTION
Removed the eventId from localStorage on the catch to fix eventual bugs.
If someone scanned a qr code the eventId would be set in his local storage. However if there is an error while joining an event: eg. he already joined the event, the program would just go to the catch clause, but the local storage would never be cleared. This means that everytime he would connect normally an alert pop up would show because he still has that eventId set in localStorage so the program will think he is trying to join an event.