### PR TITLE
feat: allow calls only from frontend domain

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,13 @@ const app = express();
 /**
  * Middleware setup.
  */
-app.use(cors());
+const corsOptions = {
+    origin: 'https://andrei2308.github.io',
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+};
+
+app.use(cors(corsOptions));
 app.use(bodyparser.json());
 app.use(bodyparser.urlencoded({ extended: true }));
 app.use(helmet({


### PR DESCRIPTION
Configured cors to only accept calls from the domain on which the frontend is hosted for better security.