### PR TITLE
fix: joining bug

### DIFF
--- a/server.js
+++ b/server.js
@@ -284,6 +284,10 @@ app.post('/events/:eventId/join', authenticateToken, async (req, res) => {
         if (isAlreadyJoined) {
             return res.status(400).json({ message: 'User already joined' });
         }
+        // Check if the event is open
+        if (event.status === "OPEN") {
+            return res.status(400).json({ message: 'Event is already in progress' });
+        }
 
         // Add the user to the participants array
         event.participants.push({


### PR DESCRIPTION
Solved the joinning event bug. Suppose the organizer gives an user a qr code while the event is closed and the user doesn't join until the event is already in progress. Then, the user shouldn't be let to join the event. Solved this by added an if condition that checks if the event is open or closed right before adding the user in the participants array.